### PR TITLE
docs: Document basic-auth-enable for Prometheus logger

### DIFF
--- a/doc/logger_prometheus.md
+++ b/doc/logger_prometheus.md
@@ -6,6 +6,7 @@ This logger generates **prometheus** metrics. Use the following Grafana [dashboa
 Options:
 - `listen-ip`: (string) listening IP
 - `listen-port`: (integer) listening port
+- `basic-auth-enable`: (bool) whether to enable basic auth
 - `basic-auth-login`: (string) default login for basic auth
 - `basic-auth-pwd`: (string) default password for basic auth
 - `tls-support`: (boolean) tls support
@@ -24,6 +25,7 @@ Default values:
 prometheus:
   listen-ip: 0.0.0.0
   listen-port: 8081
+  basic-auth-enable: true
   basic-auth-login: admin
   basic-auth-pwd: changeme
   tls-support: false


### PR DESCRIPTION
This was not documented and I had to read the code like a caveman to figure out how to disable basic auth :wink:
