### PR TITLE
Add parsing for SVCB and HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 # Python
 __pycache__/
+
+go-dnscollector

--- a/doc/dnsparser.md
+++ b/doc/dnsparser.md
@@ -14,6 +14,8 @@ The following Rdatatypes will be decoded, otherwise the `-` value will be used:
 - TXT
 - PTR
 - SOA
+- SVCB
+- HTTPS
 
 Extended DNS is also supported. 
 The following options are decoded:

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,6 @@ github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgz
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dmachard/go-dnstap-protobuf v0.5.0 h1:JGd96UkFPmztsaOoHxf8cRD4X4bWoN/HKLaMFnjDhys=
 github.com/dmachard/go-dnstap-protobuf v0.5.0/go.mod h1:l4Qme7Kg8asuB8WwL+egMmXYtBSjN7tqxymWkeyTXqw=
-github.com/dmachard/go-framestream v0.3.0 h1:rwiNAvpeGwrXZUKWM/AcmCb/prYjE8J5DOGk+Qbuwpo=
-github.com/dmachard/go-framestream v0.3.0/go.mod h1:f0LF2Npbe4plNgzVJX1rUfoIUjTWZIpLLyhuG04RTo4=
 github.com/dmachard/go-framestream v0.6.0 h1:H2DtbkXNIpM/PSuMN/DA1EDGGO5NhN/OBB2K9SkbA8c=
 github.com/dmachard/go-framestream v0.6.0/go.mod h1:f0LF2Npbe4plNgzVJX1rUfoIUjTWZIpLLyhuG04RTo4=
 github.com/dmachard/go-logger v0.3.0 h1:Q7RnOLFCU9V5RSiuFs5cEwsEXTQ4HbvFDjF2H5GPNuQ=


### PR DESCRIPTION
This PR adds support for parsing SVCB and HTTPS records.

It also contains some tests and I have run some end-to-end tests and it seems to work, but I recommend a healthy dose of reviews before merging.

I've also added a small commit that ignores the built binary in git.

- chore: ignore the built binary
- feat: Add SVCB and HTTPS parsing
