### PR TITLE
Refactor ES logger for bulk requests

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -415,6 +415,8 @@ multiplexer:
 #   chan-buffer-size: 65535
 #   # Size of batches sent to ES via _bulk
 #   bulk-size: 100
+#   # interval in seconds before to flush the buffer
+#   flush-interval: 30
 
 # # resend captured dns traffic to a remote fluentd server or to unix socket
 # fluentd:

--- a/config.yml
+++ b/config.yml
@@ -408,9 +408,13 @@ multiplexer:
 # # elasticsearch backend, basic support
 # elasticsearch:
 #   # remote server url
-#   url: "http://127.0.0.1:9200/indexname/_doc"
+#   server: "http://127.0.0.1:9200/"
+#   # Elasticsearch index for ingestion
+#   index:  "indexname"
 #   # Channel buffer size for incoming packets, number of packet before to drop it.
 #   chan-buffer-size: 65535
+#   # Size of batches sent to ES via _bulk
+#   bulk-size: 100
 
 # # resend captured dns traffic to a remote fluentd server or to unix socket
 # fluentd:

--- a/dnsutils/config.go
+++ b/dnsutils/config.go
@@ -417,6 +417,7 @@ type Config struct {
 			Server            string `yaml:"server"`
 			ChannelBufferSize int    `yaml:"chan-buffer-size"`
 			BulkSize          int    `yaml:"bulk-size"`
+			FlushInterval     int    `yaml:"flush-interval"`
 		} `yaml:"elasticsearch"`
 		ScalyrClient struct {
 			Enable            bool                   `yaml:"enable"`
@@ -720,6 +721,7 @@ func (c *Config) SetDefault() {
 	c.Loggers.ElasticSearchClient.Index = ""
 	c.Loggers.ElasticSearchClient.ChannelBufferSize = 65535
 	c.Loggers.ElasticSearchClient.BulkSize = 100
+	c.Loggers.ElasticSearchClient.FlushInterval = 10
 
 	c.Loggers.RedisPub.Enable = false
 	c.Loggers.RedisPub.RemoteAddress = LOCALHOST_IP

--- a/dnsutils/config.go
+++ b/dnsutils/config.go
@@ -413,8 +413,10 @@ type Config struct {
 		} `yaml:"statsd"`
 		ElasticSearchClient struct {
 			Enable            bool   `yaml:"enable"`
-			URL               string `yaml:"url"`
+			Index             string `yaml:"index"`
+			Server            string `yaml:"server"`
 			ChannelBufferSize int    `yaml:"chan-buffer-size"`
+			BulkSize          int    `yaml:"bulk-size"`
 		} `yaml:"elasticsearch"`
 		ScalyrClient struct {
 			Enable            bool                   `yaml:"enable"`
@@ -714,8 +716,10 @@ func (c *Config) SetDefault() {
 	c.Loggers.Statsd.ChannelBufferSize = 65535
 
 	c.Loggers.ElasticSearchClient.Enable = false
-	c.Loggers.ElasticSearchClient.URL = "http://127.0.0.1:9200/indexname/_doc"
+	c.Loggers.ElasticSearchClient.Server = "http://127.0.0.1:9200/"
+	c.Loggers.ElasticSearchClient.Index = ""
 	c.Loggers.ElasticSearchClient.ChannelBufferSize = 65535
+	c.Loggers.ElasticSearchClient.BulkSize = 100
 
 	c.Loggers.RedisPub.Enable = false
 	c.Loggers.RedisPub.RemoteAddress = LOCALHOST_IP

--- a/docs/loggers/logger_elasticsearch.md
+++ b/docs/loggers/logger_elasticsearch.md
@@ -8,6 +8,7 @@ Options:
 - `index`: (string) Elasticsearch index
 - `bulk-size`: (integer) Bulk size to be used for bulk batches
 - `chan-buffer-size`: (integer) channel buffer size used on incoming dns message, number of messages before to drop it
+- `flush-interval`: (integer) interval in seconds before to flush the buffer
 
 ```yaml
 elasticsearch:
@@ -15,4 +16,5 @@ elasticsearch:
   index:  "indexname"
   bulk-size: 100
   chan-buffer-size: 65535
+  flush-interval: 10
 ```

--- a/docs/loggers/logger_elasticsearch.md
+++ b/docs/loggers/logger_elasticsearch.md
@@ -4,11 +4,15 @@
 ElasticSearch client to remote ElasticSearch server
 
 Options:
-- `url`: (string) Elasticsearch _doc url
-- `chan-buffer-size`: (integer) channel buffer size used on incoming dns message, number of messages before to drop it.
+- `server`: (string) Elasticsearch server url
+- `index`: (string) Elasticsearch index
+- `bulk-size`: (integer) Bulk size to be used for bulk batches
+- `chan-buffer-size`: (integer) channel buffer size used on incoming dns message, number of messages before to drop it
 
 ```yaml
 elasticsearch:
-  url: "http://127.0.0.1:9200/indexname/_doc"
+  server: "http://127.0.0.1:9200"
+  index:  "indexname"
+  bulk-size: 100
   chan-buffer-size: 65535
 ```

--- a/loggers/elasticsearch_test.go
+++ b/loggers/elasticsearch_test.go
@@ -18,13 +18,11 @@ func Test_ElasticSearchClient(t *testing.T) {
 
 	testcases := []struct {
 		mode      string
-		pattern   string
 		bulkSize  int
 		inputSize int
 	}{
 		{
 			mode:      dnsutils.MODE_FLATJSON,
-			pattern:   "\"dns.qname\":\"dns.collector\"",
 			bulkSize:  10,
 			inputSize: 500,
 		},
@@ -92,6 +90,86 @@ func Test_ElasticSearchClient(t *testing.T) {
 				assert.Equal(t, tc.bulkSize*2, cnt)
 				assert.Equal(t, "http://127.0.0.1:9200/indexname/_bulk", g.bulkUrl)
 			}
+		})
+	}
+}
+
+func Test_ElasticSearchClientFlushINterval(t *testing.T) {
+
+	testcases := []struct {
+		mode          string
+		bulkSize      int
+		inputSize     int
+		flushInterval int
+	}{
+		{
+			mode:          dnsutils.MODE_FLATJSON,
+			bulkSize:      100,
+			inputSize:     99,
+			flushInterval: 5,
+		},
+	}
+
+	fakeRcvr, err := net.Listen("tcp", "127.0.0.1:9200")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fakeRcvr.Close()
+
+	for _, tc := range testcases {
+		t.Run(tc.mode, func(t *testing.T) {
+			conf := dnsutils.GetFakeConfig()
+			conf.Loggers.ElasticSearchClient.Index = "indexname"
+			conf.Loggers.ElasticSearchClient.BulkSize = tc.bulkSize
+			conf.Loggers.ElasticSearchClient.FlushInterval = tc.flushInterval
+			g := NewElasticSearchClient(conf, logger.New(false), "test")
+
+			go g.Run()
+
+			dm := dnsutils.GetFakeDnsMessage()
+
+			for i := 0; i < tc.inputSize; i++ {
+				g.Channel() <- dm
+			}
+
+			conn, err := fakeRcvr.Accept()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+
+			connReader := bufio.NewReader(conn)
+			connReaderT := bufio.NewReaderSize(connReader, tc.bulkSize*100000)
+			request, err := http.ReadRequest(connReaderT)
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn.Write([]byte(dnsutils.HTTP_OK))
+
+			// read payload from request body
+			payload, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			scanner := bufio.NewScanner(strings.NewReader(string(payload)))
+			cnt := 0
+			for scanner.Scan() {
+				if cnt%2 == 0 {
+					var res map[string]interface{}
+					json.Unmarshal(scanner.Bytes(), &res)
+					assert.Equal(t, map[string]interface{}{}, res["index"])
+				} else {
+					var bulkDm dnsutils.DnsMessage
+					err := json.Unmarshal(scanner.Bytes(), &bulkDm)
+					assert.NoError(t, err)
+				}
+				cnt++
+			}
+
+			assert.Equal(t, tc.inputSize*2, cnt)
+			assert.Equal(t, "http://127.0.0.1:9200/indexname/_bulk", g.bulkUrl)
+
 		})
 	}
 }

--- a/loggers/elasticsearch_test.go
+++ b/loggers/elasticsearch_test.go
@@ -2,25 +2,31 @@ package loggers
 
 import (
 	"bufio"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
-	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/dmachard/go-dnscollector/dnsutils"
 	"github.com/dmachard/go-logger"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ElasticSearchClient(t *testing.T) {
 
 	testcases := []struct {
-		mode    string
-		pattern string
+		mode      string
+		pattern   string
+		bulkSize  int
+		inputSize int
 	}{
 		{
-			mode:    dnsutils.MODE_FLATJSON,
-			pattern: "\"dns.qname\":\"dns.collector\"",
+			mode:      dnsutils.MODE_FLATJSON,
+			pattern:   "\"dns.qname\":\"dns.collector\"",
+			bulkSize:  10,
+			inputSize: 500,
 		},
 	}
 
@@ -33,36 +39,58 @@ func Test_ElasticSearchClient(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.mode, func(t *testing.T) {
 			conf := dnsutils.GetFakeConfig()
+			conf.Loggers.ElasticSearchClient.Index = "indexname"
+			conf.Loggers.ElasticSearchClient.BulkSize = tc.bulkSize
 			g := NewElasticSearchClient(conf, logger.New(false), "test")
 
 			go g.Run()
 
 			dm := dnsutils.GetFakeDnsMessage()
-			g.Channel() <- dm
 
-			// accept conn
-			conn, err := fakeRcvr.Accept()
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer conn.Close()
-
-			// read and parse http request on server side
-			request, err := http.ReadRequest(bufio.NewReader(conn))
-			if err != nil {
-				t.Fatal(err)
-			}
-			conn.Write([]byte(dnsutils.HTTP_OK))
-
-			// read payload from request body
-			payload, err := io.ReadAll(request.Body)
-			if err != nil {
-				t.Fatal(err)
+			for i := 0; i < tc.inputSize; i++ {
+				g.Channel() <- dm
 			}
 
-			pattern := regexp.MustCompile(tc.pattern)
-			if !pattern.MatchString(string(payload)) {
-				t.Errorf("loki test error want %s, got: %s", tc.pattern, string(payload))
+			for i := 0; i < tc.inputSize/tc.bulkSize; i++ {
+				// accept conn
+				conn, err := fakeRcvr.Accept()
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer conn.Close()
+
+				// read and parse http request on server side
+				connReader := bufio.NewReader(conn)
+				connReaderT := bufio.NewReaderSize(connReader, tc.bulkSize*100000)
+				request, err := http.ReadRequest(connReaderT)
+				if err != nil {
+					t.Fatal(err)
+				}
+				conn.Write([]byte(dnsutils.HTTP_OK))
+
+				// read payload from request body
+				payload, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				scanner := bufio.NewScanner(strings.NewReader(string(payload)))
+				cnt := 0
+				for scanner.Scan() {
+					if cnt%2 == 0 {
+						var res map[string]interface{}
+						json.Unmarshal(scanner.Bytes(), &res)
+						assert.Equal(t, map[string]interface{}{}, res["index"])
+					} else {
+						var bulkDm dnsutils.DnsMessage
+						err := json.Unmarshal(scanner.Bytes(), &bulkDm)
+						assert.NoError(t, err)
+					}
+					cnt++
+				}
+
+				assert.Equal(t, tc.bulkSize*2, cnt)
+				assert.Equal(t, "http://127.0.0.1:9200/indexname/_bulk", g.bulkUrl)
 			}
 		})
 	}


### PR DESCRIPTION
This PR is introducing bulk requests for the ES logger, introducing a new parameter called `bulk-size` and splits the previous `url` parameter in `server` and `index`.

Additionally, a new parameter (`flush-interval`) is introduced, to flush the ES buffer on a defined period.