### PR TITLE
elasticsearch logger: change op_type to create to allow sending to Data Streams

### DIFF
--- a/loggers/elasticsearch.go
+++ b/loggers/elasticsearch.go
@@ -129,7 +129,7 @@ func (o *ElasticSearchClient) FlushBuffer(buf *[]dnsutils.DnsMessage) {
 	buffer := new(bytes.Buffer)
 
 	for _, dm := range *buf {
-		buffer.WriteString("{ \"index\" : {}}")
+		buffer.WriteString("{ \"create\" : {}}")
 		buffer.WriteString("\n")
 		// encode
 		flat, err := dm.Flatten()

--- a/loggers/elasticsearch_test.go
+++ b/loggers/elasticsearch_test.go
@@ -78,7 +78,7 @@ func Test_ElasticSearchClient(t *testing.T) {
 					if cnt%2 == 0 {
 						var res map[string]interface{}
 						json.Unmarshal(scanner.Bytes(), &res)
-						assert.Equal(t, map[string]interface{}{}, res["index"])
+						assert.Equal(t, map[string]interface{}{}, res["create"])
 					} else {
 						var bulkDm dnsutils.DnsMessage
 						err := json.Unmarshal(scanner.Bytes(), &bulkDm)
@@ -158,7 +158,7 @@ func Test_ElasticSearchClientFlushINterval(t *testing.T) {
 				if cnt%2 == 0 {
 					var res map[string]interface{}
 					json.Unmarshal(scanner.Bytes(), &res)
-					assert.Equal(t, map[string]interface{}{}, res["index"])
+					assert.Equal(t, map[string]interface{}{}, res["create"])
 				} else {
 					var bulkDm dnsutils.DnsMessage
 					err := json.Unmarshal(scanner.Bytes(), &bulkDm)


### PR DESCRIPTION
Since 0.35 indexing to elasticsearch does no longer work if the destination is a Data Stream.
This is because Data Streams only allow "create" (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html)

This pull request changes the "index" to a "create" op_type which allows sending logs to a Data Stream again. 
"index" should not be needed as we never update existing documents.
