### PR TITLE
Support building for FreeBSD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,22 @@ jobs:
     - name: build binary
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-dnscollector *.go
 
+  go-freebsd:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        go-version: [ '1.20', '1.21' ]
+        
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: build binary
+      run: CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 go build -o go-dnscollector *.go
+
   # for macos and window, limit the build to the latest version
   go-macos:
     runs-on: macos-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
     - windows
     - linux
     - darwin
+    - freebsd
   goarch:
     - amd64
     - arm64

--- a/collectors/sniffer_afpacket.go
+++ b/collectors/sniffer_afpacket.go
@@ -1,5 +1,5 @@
-//go:build linux || freebsd
-// +build linux freebsd
+//go:build linux
+// +build linux
 
 package collectors
 

--- a/collectors/sniffer_afpacket_freebsd.go
+++ b/collectors/sniffer_afpacket_freebsd.go
@@ -1,0 +1,78 @@
+//go:build freebsd
+// +build freebsd
+
+package collectors
+
+import (
+	"github.com/dmachard/go-dnscollector/dnsutils"
+	"github.com/dmachard/go-logger"
+)
+
+type AfpacketSniffer struct {
+	done    chan bool
+	exit    chan bool
+	loggers []dnsutils.Worker
+	config  *dnsutils.Config
+	logger  *logger.Logger
+	name    string
+}
+
+// workaround for freebsd, not yet supported
+func NewAfpacketSniffer(loggers []dnsutils.Worker, config *dnsutils.Config, logger *logger.Logger, name string) *AfpacketSniffer {
+	logger.Info("[%s] AFPACKET sniffer - enabled", name)
+	s := &AfpacketSniffer{
+		done:    make(chan bool),
+		exit:    make(chan bool),
+		config:  config,
+		loggers: loggers,
+		logger:  logger,
+		name:    name,
+	}
+	s.ReadConfig()
+	return s
+}
+
+func (c *AfpacketSniffer) GetName() string { return c.name }
+
+func (c *AfpacketSniffer) SetLoggers(loggers []dnsutils.Worker) {
+	c.loggers = loggers
+}
+
+func (c *AfpacketSniffer) LogInfo(msg string, v ...interface{}) {
+	c.logger.Info("["+c.name+"] AFPACKET sniffer - "+msg, v...)
+}
+
+func (c *AfpacketSniffer) LogError(msg string, v ...interface{}) {
+	c.logger.Error("["+c.name+"] AFPACKET sniffer - "+msg, v...)
+}
+
+func (c *AfpacketSniffer) Loggers() []chan dnsutils.DnsMessage {
+	channels := []chan dnsutils.DnsMessage{}
+	for _, p := range c.loggers {
+		channels = append(channels, p.Channel())
+	}
+	return channels
+}
+
+func (c *AfpacketSniffer) ReadConfig() {
+}
+
+func (c *AfpacketSniffer) Channel() chan dnsutils.DnsMessage {
+	return nil
+}
+
+func (c *AfpacketSniffer) Stop() {
+	c.LogInfo("stopping...")
+
+	// exit to close properly
+	c.exit <- true
+
+	// read done channel and block until run is terminated
+	<-c.done
+	close(c.done)
+}
+
+func (c *AfpacketSniffer) Run() {
+	c.LogInfo("Not supported")
+	c.done <- true
+}

--- a/collectors/tzsp_freebsd.go
+++ b/collectors/tzsp_freebsd.go
@@ -1,0 +1,78 @@
+//go:build freebsd
+// +build freebsd
+
+package collectors
+
+import (
+	"github.com/dmachard/go-dnscollector/dnsutils"
+	"github.com/dmachard/go-logger"
+)
+
+type TzspSniffer struct {
+	done    chan bool
+	exit    chan bool
+	loggers []dnsutils.Worker
+	config  *dnsutils.Config
+	logger  *logger.Logger
+	name    string
+}
+
+// workaround for macos, not yet supported
+func NewTzsp(loggers []dnsutils.Worker, config *dnsutils.Config, logger *logger.Logger, name string) *AfpacketSniffer {
+	logger.Info("[%s] tzsp collector - enabled", name)
+	s := &AfpacketSniffer{
+		done:    make(chan bool),
+		exit:    make(chan bool),
+		config:  config,
+		loggers: loggers,
+		logger:  logger,
+		name:    name,
+	}
+	s.ReadConfig()
+	return s
+}
+
+func (c *TzspSniffer) GetName() string { return c.name }
+
+func (c *TzspSniffer) SetLoggers(loggers []dnsutils.Worker) {
+	c.loggers = loggers
+}
+
+func (c *TzspSniffer) LogInfo(msg string, v ...interface{}) {
+	c.logger.Info("["+c.name+"] tzsp collector - "+msg, v...)
+}
+
+func (c *TzspSniffer) LogError(msg string, v ...interface{}) {
+	c.logger.Error("["+c.name+"] tzsp collector - "+msg, v...)
+}
+
+func (c *TzspSniffer) Loggers() []chan dnsutils.DnsMessage {
+	channels := []chan dnsutils.DnsMessage{}
+	for _, p := range c.loggers {
+		channels = append(channels, p.Channel())
+	}
+	return channels
+}
+
+func (c *TzspSniffer) ReadConfig() {
+}
+
+func (c *TzspSniffer) Channel() chan dnsutils.DnsMessage {
+	return nil
+}
+
+func (c *TzspSniffer) Stop() {
+	c.LogInfo("stopping...")
+
+	// exit to close properly
+	c.exit <- true
+
+	// read done channel and block until run is terminated
+	<-c.done
+	close(c.done)
+}
+
+func (c *TzspSniffer) Run() {
+	c.LogInfo("run terminated")
+	c.done <- true
+}


### PR DESCRIPTION
This PR allows building the DNS Collector for FreeBSD. This build disables the AF_PACKET and tzsp sniffers for such builds.
