### PR TITLE
Use prometheus/version lib, change on build_info metric

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,11 @@ builds:
     - CGO_ENABLED=0
 
   ldflags:
-    - '-X main.Version={{.Version}}'
+    - -s -w
+    - -X github.com/prometheus/common/version.Version={{.Version}}
+    - -X github.com/prometheus/common/version.Revision={{.Commit}}
+    - -X github.com/prometheus/common/version.Branch={{.Branch}}
+    - -X github.com/prometheus/common/version.BuildDate={{.Date}}
 
   goos:
     - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     - CGO_ENABLED=0
 
   ldflags:
-    - -s -w
+  #  - -s -w
     - -X github.com/prometheus/common/version.Version={{.Version}}
     - -X github.com/prometheus/common/version.Revision={{.Commit}}
     - -X github.com/prometheus/common/version.Branch={{.Branch}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,6 @@ builds:
     - CGO_ENABLED=0
 
   ldflags:
-  #  - -s -w
     - -X github.com/prometheus/common/version.Version={{.Version}}
     - -X github.com/prometheus/common/version.Revision={{.Commit}}
     - -X github.com/prometheus/common/version.Branch={{.Branch}}

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,11 @@ GO_FRAMESTREAM := 0.6.0
 BUILD_TIME := $(shell LANG=en_US date +"%F_%T_%z")
 COMMIT := $(shell git rev-parse --short HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-VERSION ?= $(shell git describe --tags ${COMMIT} 2>/dev/null | cut -c2-)
+VERSION ?= $(shell git describe --tags --abbrev=0 ${COMMIT} 2>/dev/null | cut -c2-)
 VERSION := $(or $(VERSION),$(COMMIT))
 
 LD_FLAGS ?=
-#LD_FLAGS += -X main.Version=$(VERSION)
-
+LD_FLAGS += -s -w # turns off debugging information to get the smallest binaries
 LD_FLAGS += -X github.com/prometheus/common/version.Version=$(VERSION)
 LD_FLAGS += -X github.com/prometheus/common/version.Revision=$(COMMIT)
 LD_FLAGS += -X github.com/prometheus/common/version.Branch=$(BRANCH)
@@ -43,6 +42,9 @@ build:
 run: build
 	./${BINARY_NAME}
 
+version: build
+	./${BINARY_NAME} -v
+
 lint:
 	$(GOPATH)/bin/golangci-lint run --config=.golangci.yml ./...
 	
@@ -51,7 +53,7 @@ test:
 	@go test ./netlib/ -race -cover -v
 	@go test -timeout 30s ./transformers/ -race -cover -v
 	@go test -timeout 30s ./collectors/ -race -cover -v
-	@go test -timeout 60s ./loggers/ -race -cover -v
+	@go test -timeout 90s ./loggers/ -race -cover -v
 
 clean:
 	@go clean

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,12 @@ VERSION ?= $(shell git describe --tags ${COMMIT} 2>/dev/null | cut -c2-)
 VERSION := $(or $(VERSION),$(COMMIT))
 
 LD_FLAGS ?=
-LD_FLAGS += -X main.Version=$(VERSION)
+#LD_FLAGS += -X main.Version=$(VERSION)
+
+LD_FLAGS += -X github.com/prometheus/common/version.Version=$(VERSION)
+LD_FLAGS += -X github.com/prometheus/common/version.Revision=$(COMMIT)
+LD_FLAGS += -X github.com/prometheus/common/version.Branch=$(BRANCH)
+LD_FLAGS += -X github.com/prometheus/common/version.BuildDate=$(BUILD_TIME)
 
 ifndef $(GOPATH)
 	GOPATH=$(shell go env GOPATH)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VERSION ?= $(shell git describe --tags --abbrev=0 ${COMMIT} 2>/dev/null | cut -c
 VERSION := $(or $(VERSION),$(COMMIT))
 
 LD_FLAGS ?=
-LD_FLAGS += -s -w # turns off debugging information to get the smallest binaries
+#LD_FLAGS += -s -w # turns off debugging information to get the smallest binaries
 LD_FLAGS += -X github.com/prometheus/common/version.Version=$(VERSION)
 LD_FLAGS += -X github.com/prometheus/common/version.Revision=$(COMMIT)
 LD_FLAGS += -X github.com/prometheus/common/version.Branch=$(BRANCH)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ VERSION ?= $(shell git describe --tags --abbrev=0 ${COMMIT} 2>/dev/null | cut -c
 VERSION := $(or $(VERSION),$(COMMIT))
 
 LD_FLAGS ?=
-#LD_FLAGS += -s -w # turns off debugging information to get the smallest binaries
 LD_FLAGS += -X github.com/prometheus/common/version.Version=$(VERSION)
 LD_FLAGS += -X github.com/prometheus/common/version.Revision=$(COMMIT)
 LD_FLAGS += -X github.com/prometheus/common/version.Branch=$(BRANCH)

--- a/dnscollector.go
+++ b/dnscollector.go
@@ -16,13 +16,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// Version is the package version, value is set during build phase
-var Version = "0.0.0"
-
 func showVersion() {
-	fmt.Println("version: ", version.Version)
-	fmt.Println("revision: ", version.Revision)
-	fmt.Println("build date: ", version.BuildDate)
+	fmt.Println(version.Version)
 }
 
 func printUsage() {
@@ -128,7 +123,7 @@ func main() {
 	// enable the verbose mode ?
 	logger.SetVerbose(config.Global.Trace.Verbose)
 
-	logger.Info("main - version=%s", version.Version)
+	logger.Info("main - version=%s revision=%s", version.Version, version.Revision)
 	logger.Info("main - starting dns-collector...")
 
 	// load loggers
@@ -162,10 +157,10 @@ func main() {
 		}
 
 		if subcfg.Loggers.RestAPI.Enable && IsLoggerRouted(config, output.Name) {
-			mapLoggers[output.Name] = loggers.NewRestAPI(subcfg, logger, Version, output.Name)
+			mapLoggers[output.Name] = loggers.NewRestAPI(subcfg, logger, output.Name)
 		}
 		if subcfg.Loggers.Prometheus.Enable && IsLoggerRouted(config, output.Name) {
-			mapLoggers[output.Name] = loggers.NewPrometheus(subcfg, logger, Version, output.Name)
+			mapLoggers[output.Name] = loggers.NewPrometheus(subcfg, logger, output.Name)
 		}
 		if subcfg.Loggers.Stdout.Enable && IsLoggerRouted(config, output.Name) {
 			mapLoggers[output.Name] = loggers.NewStdOut(subcfg, logger, output.Name)
@@ -192,7 +187,7 @@ func main() {
 			mapLoggers[output.Name] = loggers.NewLokiClient(subcfg, logger, output.Name)
 		}
 		if subcfg.Loggers.Statsd.Enable && IsLoggerRouted(config, output.Name) {
-			mapLoggers[output.Name] = loggers.NewStatsdClient(subcfg, logger, Version, output.Name)
+			mapLoggers[output.Name] = loggers.NewStatsdClient(subcfg, logger, output.Name)
 		}
 		if subcfg.Loggers.ElasticSearchClient.Enable && IsLoggerRouted(config, output.Name) {
 			mapLoggers[output.Name] = loggers.NewElasticSearchClient(subcfg, logger, output.Name)

--- a/dnscollector.go
+++ b/dnscollector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dmachard/go-dnscollector/loggers"
 	"github.com/dmachard/go-logger"
 	"github.com/natefinch/lumberjack"
+	"github.com/prometheus/common/version"
 	"gopkg.in/yaml.v2"
 )
 
@@ -19,7 +20,9 @@ import (
 var Version = "0.0.0"
 
 func showVersion() {
-	fmt.Println(Version)
+	fmt.Println("version: ", version.Version)
+	fmt.Println("revision: ", version.Revision)
+	fmt.Println("build date: ", version.BuildDate)
 }
 
 func printUsage() {
@@ -125,7 +128,7 @@ func main() {
 	// enable the verbose mode ?
 	logger.SetVerbose(config.Global.Trace.Verbose)
 
-	logger.Info("main - version %s", Version)
+	logger.Info("main - version=%s", version.Version)
 	logger.Info("main - starting dns-collector...")
 
 	// load loggers

--- a/docs/metrics.txt
+++ b/docs/metrics.txt
@@ -1,6 +1,6 @@
-# HELP dnscollector_build_info Build version
+# HELP dnscollector_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which dnscollector was built, and the goos and goarch for the build.
 # TYPE dnscollector_build_info gauge
-dnscollector_build_info{version="0.0.0"} 1
+dnscollector_build_info{branch="main",goarch="amd64",goos="linux",goversion="go1.21.3",revision="9fde998",tags="unknown",version="0.37.0-beta1"} 1
 # HELP dnscollector_bytes_total The total bytes received and sent
 # TYPE dnscollector_bytes_total counter
 dnscollector_bytes_total{stream_id="dnsdist_pdns2"} 5.6543221e+07

--- a/loggers/prometheus.go
+++ b/loggers/prometheus.go
@@ -177,8 +177,6 @@ type Prometheus struct {
 	catalogueLabels []string
 	counters        *PromCounterCatalogueContainer
 
-	// gaugeBuildInfo *prometheus.GaugeVec
-
 	// All metrics use these descriptions when regestering
 	gaugeTopDomains    *prometheus.Desc
 	gaugeTopNxDomains  *prometheus.Desc
@@ -748,9 +746,6 @@ func NewPrometheus(config *dnsutils.Config, logger *logger.Logger, name string) 
 	// init prometheus
 	o.InitProm()
 
-	// add build version in metrics
-	//o.gaugeBuildInfo.WithLabelValues(o.version).Set(1)
-
 	// midleware to add basic authentication
 	authMiddleware := func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -790,14 +785,7 @@ func (o *Prometheus) InitProm() {
 
 	prom_prefix := SanitizeMetricName(o.config.Loggers.Prometheus.PromPrefix)
 
-	// o.gaugeBuildInfo = prometheus.NewGaugeVec(
-	// 	prometheus.GaugeOpts{
-	// 		Name: fmt.Sprintf("%s_build_info", prom_prefix),
-	// 		Help: "Build version",
-	// 	},
-	// 	[]string{"version"},
-	// )
-	// o.promRegistry.MustRegister(o.gaugeBuildInfo)
+	// register metric about current version information.
 	o.promRegistry.MustRegister(version.NewCollector(prom_prefix))
 
 	// export Go runtime metrics

--- a/loggers/prometheus.go
+++ b/loggers/prometheus.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
 	// _ "net/http/pprof"
 )
 
@@ -170,13 +171,13 @@ type Prometheus struct {
 	config       *dnsutils.Config
 	logger       *logger.Logger
 	promRegistry *prometheus.Registry
-	version      string
+	//version      string
 
 	sync.Mutex
 	catalogueLabels []string
 	counters        *PromCounterCatalogueContainer
 
-	gaugeBuildInfo *prometheus.GaugeVec
+	// gaugeBuildInfo *prometheus.GaugeVec
 
 	// All metrics use these descriptions when regestering
 	gaugeTopDomains    *prometheus.Desc
@@ -722,7 +723,7 @@ func CreateSystemCatalogue(prom *Prometheus) ([]string, *PromCounterCatalogueCon
 	)
 }
 
-func NewPrometheus(config *dnsutils.Config, logger *logger.Logger, version string, name string) *Prometheus {
+func NewPrometheus(config *dnsutils.Config, logger *logger.Logger, name string) *Prometheus {
 	logger.Info("[%s] logger=prometheus - enabled", name)
 	o := &Prometheus{
 		doneApi:     make(chan bool),
@@ -734,7 +735,7 @@ func NewPrometheus(config *dnsutils.Config, logger *logger.Logger, version strin
 		inputChan:   make(chan dnsutils.DnsMessage, config.Loggers.Prometheus.ChannelBufferSize),
 		outputChan:  make(chan dnsutils.DnsMessage, config.Loggers.Prometheus.ChannelBufferSize),
 		logger:      logger,
-		version:     version,
+		//version:     version,
 
 		promRegistry: prometheus.NewPedanticRegistry(),
 
@@ -748,7 +749,7 @@ func NewPrometheus(config *dnsutils.Config, logger *logger.Logger, version strin
 	o.InitProm()
 
 	// add build version in metrics
-	o.gaugeBuildInfo.WithLabelValues(o.version).Set(1)
+	//o.gaugeBuildInfo.WithLabelValues(o.version).Set(1)
 
 	// midleware to add basic authentication
 	authMiddleware := func(handler http.Handler) http.Handler {
@@ -789,14 +790,15 @@ func (o *Prometheus) InitProm() {
 
 	prom_prefix := SanitizeMetricName(o.config.Loggers.Prometheus.PromPrefix)
 
-	o.gaugeBuildInfo = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: fmt.Sprintf("%s_build_info", prom_prefix),
-			Help: "Build version",
-		},
-		[]string{"version"},
-	)
-	o.promRegistry.MustRegister(o.gaugeBuildInfo)
+	// o.gaugeBuildInfo = prometheus.NewGaugeVec(
+	// 	prometheus.GaugeOpts{
+	// 		Name: fmt.Sprintf("%s_build_info", prom_prefix),
+	// 		Help: "Build version",
+	// 	},
+	// 	[]string{"version"},
+	// )
+	// o.promRegistry.MustRegister(o.gaugeBuildInfo)
+	o.promRegistry.MustRegister(version.NewCollector(prom_prefix))
 
 	// export Go runtime metrics
 	o.promRegistry.MustRegister(

--- a/loggers/prometheus_test.go
+++ b/loggers/prometheus_test.go
@@ -21,7 +21,7 @@ const (
 func TestPrometheus_BadAuth(t *testing.T) {
 	// init the logger
 	config := dnsutils.GetFakeConfig()
-	g := NewPrometheus(config, logger.New(false), "dev", "test")
+	g := NewPrometheus(config, logger.New(false), "test")
 
 	tt := []struct {
 		name       string
@@ -74,7 +74,7 @@ func TestPrometheus_GetMetrics(t *testing.T) {
 // func getMetricsHelper(config *dnsutils.Config, labels map[string]string, t *testing.T) {
 func getMetricsTestCase(config *dnsutils.Config, labels map[string]string) func(t *testing.T) {
 	return func(t *testing.T) {
-		g := NewPrometheus(config, logger.New(false), "dev", "test")
+		g := NewPrometheus(config, logger.New(false), "test")
 
 		// record one dns message to simulate some incoming data
 		noerror_record := dnsutils.GetFakeDnsMessage()
@@ -166,7 +166,7 @@ func getMetricsTestCase(config *dnsutils.Config, labels map[string]string) func(
 // Test that EPS (Events Per Second) Counters increment correctly
 func TestPrometheus_EPS_Counters(t *testing.T) {
 	config := dnsutils.GetFakeConfig()
-	g := NewPrometheus(config, logger.New(false), "dev", "test")
+	g := NewPrometheus(config, logger.New(false), "test")
 
 	// record one dns message to simulate some incoming data
 	noerror_record := dnsutils.GetFakeDnsMessage()
@@ -207,7 +207,7 @@ func TestPrometheus_EPS_Counters(t *testing.T) {
 func TestPrometheus_BuildInfo(t *testing.T) {
 	config := dnsutils.GetFakeConfig()
 	// config.Loggers.Prometheus.HistogramMetricsEnabled = true
-	g := NewPrometheus(config, logger.New(false), "dev", "test")
+	g := NewPrometheus(config, logger.New(false), "test")
 
 	mf := getMetrics(g, t)
 
@@ -220,7 +220,7 @@ func TestPrometheus_BuildInfo(t *testing.T) {
 func TestPrometheus_ConfirmDifferentResolvers(t *testing.T) {
 	config := dnsutils.GetFakeConfig()
 	config.Loggers.Prometheus.LabelsList = []string{"resolver"}
-	g := NewPrometheus(config, logger.New(false), "dev", "test")
+	g := NewPrometheus(config, logger.New(false), "test")
 	noerror_record := dnsutils.GetFakeDnsMessage()
 	noerror_record.DNS.Length = 123
 	noerror_record.NetworkInfo.ResponseIp = "1.2.3.4"

--- a/loggers/restapi.go
+++ b/loggers/restapi.go
@@ -70,7 +70,7 @@ type RestAPI struct {
 	sync.RWMutex
 }
 
-func NewRestAPI(config *dnsutils.Config, logger *logger.Logger, version string, name string) *RestAPI {
+func NewRestAPI(config *dnsutils.Config, logger *logger.Logger, name string) *RestAPI {
 	logger.Info("[%s] logger=restapi - enabled", name)
 	o := &RestAPI{
 		doneApi:     make(chan bool),

--- a/loggers/restapi_test.go
+++ b/loggers/restapi_test.go
@@ -14,7 +14,7 @@ import (
 func TestRestAPI_BadBasicAuth(t *testing.T) {
 	// init the logger
 	config := dnsutils.GetFakeConfig()
-	g := NewRestAPI(config, logger.New(false), "dev", "test")
+	g := NewRestAPI(config, logger.New(false), "test")
 
 	tt := []struct {
 		name       string
@@ -60,7 +60,7 @@ func TestRestAPI_BadBasicAuth(t *testing.T) {
 func TestRestAPI_MethodNotAllowed(t *testing.T) {
 	// init the logger
 	config := dnsutils.GetFakeConfig()
-	g := NewRestAPI(config, logger.New(false), "dev", "test")
+	g := NewRestAPI(config, logger.New(false), "test")
 
 	// record one dns message to simulate some incoming data
 	dm := dnsutils.GetFakeDnsMessage()
@@ -150,7 +150,7 @@ func TestRestAPI_MethodNotAllowed(t *testing.T) {
 func TestRestAPI_GetMethod(t *testing.T) {
 	// init the logger
 	config := dnsutils.GetFakeConfig()
-	g := NewRestAPI(config, logger.New(false), "dev", "test")
+	g := NewRestAPI(config, logger.New(false), "test")
 
 	tt := []struct {
 		name       string

--- a/loggers/statsd.go
+++ b/loggers/statsd.go
@@ -50,14 +50,13 @@ type StatsdClient struct {
 	outputChan  chan dnsutils.DnsMessage
 	config      *dnsutils.Config
 	logger      *logger.Logger
-	version     string
 	name        string
 
 	Stats StreamStats
 	sync.RWMutex
 }
 
-func NewStatsdClient(config *dnsutils.Config, logger *logger.Logger, version string, name string) *StatsdClient {
+func NewStatsdClient(config *dnsutils.Config, logger *logger.Logger, name string) *StatsdClient {
 	logger.Info("[%s] logger=statsd - enabled", name)
 
 	s := &StatsdClient{
@@ -69,7 +68,6 @@ func NewStatsdClient(config *dnsutils.Config, logger *logger.Logger, version str
 		outputChan:  make(chan dnsutils.DnsMessage, config.Loggers.Statsd.ChannelBufferSize),
 		logger:      logger,
 		config:      config,
-		version:     version,
 		name:        name,
 		Stats:       StreamStats{Streams: make(map[string]*StatsPerStream)},
 	}

--- a/loggers/statsd_test.go
+++ b/loggers/statsd_test.go
@@ -13,7 +13,7 @@ func TestStatsdRun(t *testing.T) {
 	config := dnsutils.GetFakeConfig()
 	config.Loggers.Statsd.FlushInterval = 1
 
-	g := NewStatsdClient(config, logger.New(false), "1.2.3", "test")
+	g := NewStatsdClient(config, logger.New(false), "test")
 
 	// fake msgpack receiver
 	fakeRcvr, err := net.ListenPacket(dnsutils.SOCKET_UDP, "127.0.0.1:8125")


### PR DESCRIPTION
pull request for #276 

The new build_info metric:

`dnscollector_build_info{branch="main",goarch="amd64",goos="linux",goversion="go1.21.3",revision="9fde998",tags="unknown",version="0.37.0-beta1"} 1`
