### PR TITLE
dnstap collector: new settings to disable dnsparser

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -109,6 +109,8 @@ multiplexer:
 #   reset-conn: true
 #   # Channel buffer size for incoming packets, number of packet before to drop it.
 #   chan-buffer-size: 65535
+#   # Disable the minimalist DNS parser
+#   disable-dnsparser: true
 
 # # dnstap proxifier with no protobuf decoding.
 # dnstap-proxifier:

--- a/dnsutils/config.go
+++ b/dnsutils/config.go
@@ -186,6 +186,7 @@ type Config struct {
 			RcvBufSize        int    `yaml:"sock-rcvbuf"`
 			ResetConn         bool   `yaml:"reset-conn"`
 			ChannelBufferSize int    `yaml:"chan-buffer-size"`
+			DisableDNSParser  bool   `yaml:"disable-dnsparser"`
 		} `yaml:"dnstap"`
 		DnstapProxifier struct {
 			Enable        bool   `yaml:"enable"`
@@ -549,6 +550,7 @@ func (c *Config) SetDefault() {
 	c.Collectors.Dnstap.RcvBufSize = 0
 	c.Collectors.Dnstap.ResetConn = true
 	c.Collectors.Dnstap.ChannelBufferSize = 65535
+	c.Collectors.Dnstap.DisableDNSParser = false
 
 	c.Collectors.DnstapProxifier.Enable = false
 	c.Collectors.DnstapProxifier.ListenIP = ANY_IP

--- a/dnsutils/message.go
+++ b/dnsutils/message.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dmachard/go-dnstap-protobuf"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"github.com/miekg/dns"
 	"github.com/nqd/flat"
 	"google.golang.org/protobuf/proto"
 )
@@ -731,7 +732,7 @@ func (dm *DnsMessage) ToPacketLayer() ([]gopacket.SerializableLayer, error) {
 		ip6.SrcIP = net.ParseIP(srcIp)
 		ip6.DstIP = net.ParseIP(dstIp)
 	default:
-		return nil, errors.New("family " + dm.NetworkInfo.Family + " not yet implemented")
+		return nil, errors.New("family (" + dm.NetworkInfo.Family + ") not yet implemented")
 	}
 
 	// set transport
@@ -828,5 +829,19 @@ func GetFakeDnsMessage() DnsMessage {
 	dm.NetworkInfo.ResponsePort = "4321"
 	dm.DNS.Rcode = "NOERROR"
 	dm.DNS.Qtype = "A"
+	return dm
+}
+
+func GetFakeDnsMessageWithPayload() DnsMessage {
+	// fake dns query payload
+	dnsmsg := new(dns.Msg)
+	dnsmsg.SetQuestion("dnscollector.dev.", dns.TypeA)
+	dnsquestion, _ := dnsmsg.Pack()
+
+	dm := GetFakeDnsMessage()
+	dm.NetworkInfo.Family = PROTO_IPV4
+	dm.NetworkInfo.Protocol = PROTO_UDP
+	dm.DNS.Payload = dnsquestion
+	dm.DNS.Length = len(dnsquestion)
 	return dm
 }

--- a/docs/collectors/collector_dnstap.md
+++ b/docs/collectors/collector_dnstap.md
@@ -17,6 +17,7 @@ Options:
 - `sock-rcvbuf`: (integer) sets the socket receive buffer in bytes SO_RCVBUF, set to zero to use the default system value
 - `reset-conn`: (bool) Reset TCP connection on exit
 - `chan-buffer-size`: (integer) channel buffer size used on incoming packet, number of packet before to drop it.
+- `disable-dnsparser"`: (bool) disable the minimalist DNS parser
 
 Default values:
 
@@ -32,6 +33,7 @@ dnstap:
   sock-rcvbuf: 0
   reset-conn: true
   chan-buffer-size: 65535
+  disable-dnsparser: false
 ```
 
 ## DNS tap Proxifier

--- a/loggers/stdout.go
+++ b/loggers/stdout.go
@@ -187,9 +187,14 @@ PROCESS_LOOP:
 
 			switch o.config.Loggers.Stdout.Mode {
 			case dnsutils.MODE_PCAP:
+				if len(dm.DNS.Payload) == 0 {
+					o.LogError("no dns payload to encode, drop it!")
+					continue
+				}
+
 				pkt, err := dm.ToPacketLayer()
 				if err != nil {
-					o.LogError("failed to encode to packet layer: %s", err)
+					o.LogError("unable to pack layer: %s", err)
 					continue
 				}
 

--- a/loggers/stdout.go
+++ b/loggers/stdout.go
@@ -3,6 +3,7 @@ package loggers
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -39,7 +40,8 @@ type StdOut struct {
 	config      *dnsutils.Config
 	configChan  chan *dnsutils.Config
 	logger      *logger.Logger
-	stdout      *log.Logger
+	writerText  *log.Logger
+	writerPcap  *pcapgo.Writer
 	name        string
 }
 
@@ -55,7 +57,7 @@ func NewStdOut(config *dnsutils.Config, console *logger.Logger, name string) *St
 		logger:      console,
 		config:      config,
 		configChan:  make(chan *dnsutils.Config),
-		stdout:      log.New(os.Stdout, "", 0),
+		writerText:  log.New(os.Stdout, "", 0),
 		name:        name,
 	}
 	o.ReadConfig()
@@ -70,6 +72,7 @@ func (c *StdOut) ReadConfig() {
 	if !IsStdoutValidMode(c.config.Loggers.Stdout.Mode) {
 		c.logger.Fatal("["+c.name+"] logger=stdout - invalid mode: ", c.config.Loggers.Stdout.Mode)
 	}
+
 	if len(c.config.Loggers.Stdout.TextFormat) > 0 {
 		c.textFormat = strings.Fields(c.config.Loggers.Stdout.TextFormat)
 	} else {
@@ -90,8 +93,18 @@ func (c *StdOut) LogError(msg string, v ...interface{}) {
 	c.logger.Error("["+c.name+"] logger=stdout - "+msg, v...)
 }
 
-func (o *StdOut) SetBuffer(b *bytes.Buffer) {
-	o.stdout.SetOutput(b)
+func (o *StdOut) SetTextWriter(b *bytes.Buffer) {
+	o.writerText = log.New(os.Stdout, "", 0)
+	o.writerText.SetOutput(b)
+}
+
+func (o *StdOut) SetPcapWriter(w io.Writer) {
+	o.LogInfo("init pcap writer")
+
+	o.writerPcap = pcapgo.NewWriter(w)
+	if err := o.writerPcap.WriteFileHeader(65536, layers.LinkTypeEthernet); err != nil {
+		o.logger.Fatal("["+o.name+"] logger=stdout - pcap init error: %e", err)
+	}
 }
 
 func (o *StdOut) Channel() chan dnsutils.DnsMessage {
@@ -140,7 +153,7 @@ RUN_LOOP:
 
 		case dm, opened := <-o.inputChan:
 			if !opened {
-				o.LogInfo("input channel closed!")
+				o.LogInfo("run: input channel closed!")
 				return
 			}
 
@@ -162,13 +175,8 @@ func (o *StdOut) Process() {
 	// standard output buffer
 	buffer := new(bytes.Buffer)
 
-	// pcap init ?
-	var writerPcap *pcapgo.Writer
-	if o.config.Loggers.Stdout.Mode == dnsutils.MODE_PCAP {
-		writerPcap = pcapgo.NewWriter(os.Stdout)
-		if err := writerPcap.WriteFileHeader(65536, layers.LinkTypeEthernet); err != nil {
-			o.LogError("pcap init error: %e", err)
-		}
+	if o.config.Loggers.Stdout.Mode == dnsutils.MODE_PCAP && o.writerPcap == nil {
+		o.SetPcapWriter(os.Stdout)
 	}
 
 	o.LogInfo("ready to process")
@@ -181,14 +189,14 @@ PROCESS_LOOP:
 
 		case dm, opened := <-o.outputChan:
 			if !opened {
-				o.LogInfo("output channel closed!")
+				o.LogInfo("process: output channel closed!")
 				return
 			}
 
 			switch o.config.Loggers.Stdout.Mode {
 			case dnsutils.MODE_PCAP:
 				if len(dm.DNS.Payload) == 0 {
-					o.LogError("no dns payload to encode, drop it!")
+					o.LogError("process: no dns payload to encode, drop it")
 					continue
 				}
 
@@ -214,25 +222,25 @@ PROCESS_LOOP:
 					Length:        bufSize,
 				}
 
-				writerPcap.WritePacket(ci, buf.Bytes())
+				o.writerPcap.WritePacket(ci, buf.Bytes())
 
 			case dnsutils.MODE_TEXT:
-				o.stdout.Print(dm.String(o.textFormat,
+				o.writerText.Print(dm.String(o.textFormat,
 					o.config.Global.TextFormatDelimiter,
 					o.config.Global.TextFormatBoundary))
 
 			case dnsutils.MODE_JSON:
 				json.NewEncoder(buffer).Encode(dm)
-				o.stdout.Print(buffer.String())
+				o.writerText.Print(buffer.String())
 				buffer.Reset()
 
 			case dnsutils.MODE_FLATJSON:
 				flat, err := dm.Flatten()
 				if err != nil {
-					o.LogError("flattening DNS message failed: %e", err)
+					o.LogError("process: flattening DNS message failed: %e", err)
 				}
 				json.NewEncoder(buffer).Encode(flat)
-				o.stdout.Print(buffer.String())
+				o.writerText.Print(buffer.String())
 				buffer.Reset()
 			}
 		}

--- a/processors/dnstap.go
+++ b/processors/dnstap.go
@@ -260,20 +260,22 @@ RUN_LOOP:
 			dm.DnsTap.Timestamp = ts.UnixNano()
 			dm.DnsTap.TimestampRFC3339 = ts.UTC().Format(time.RFC3339Nano)
 
-			// decode the dns payload to get id, rcode and the number of question
-			// number of answer, ignore invalid packet
-			dnsHeader, err := dnsutils.DecodeDns(dm.DNS.Payload)
-			if err != nil {
-				// parser error
-				dm.DNS.MalformedPacket = true
-				d.LogInfo("dns parser malformed packet: %s", err)
-			}
+			if !d.config.Collectors.Dnstap.DisableDNSParser {
+				// decode the dns payload to get id, rcode and the number of question
+				// number of answer, ignore invalid packet
+				dnsHeader, err := dnsutils.DecodeDns(dm.DNS.Payload)
+				if err != nil {
+					// parser error
+					dm.DNS.MalformedPacket = true
+					d.LogInfo("dns parser malformed packet: %s", err)
+				}
 
-			if err = dnsutils.DecodePayload(&dm, &dnsHeader, d.config); err != nil {
-				// decoding error
-				if d.config.Global.Trace.LogMalformed {
-					d.LogError("%v - %v", err, dm)
-					d.LogError("dump invalid dns payload: %v", dm.DNS.Payload)
+				if err = dnsutils.DecodePayload(&dm, &dnsHeader, d.config); err != nil {
+					// decoding error
+					if d.config.Global.Trace.LogMalformed {
+						d.LogError("%v - %v", err, dm)
+						d.LogError("dump invalid dns payload: %v", dm.DNS.Payload)
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR add the `disable-dnsparser` setting to disable the embedded DNS parser