### PR TITLE
powerdns collector: replace go/dnsmessage by miekg/dns

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -70,6 +70,7 @@ multiplexer:
       dnstap:
         listen-ip: 0.0.0.0
         listen-port: 6000
+        add-dns-payload: false
       transforms:
         normalize:
           qname-lowercase: false
@@ -199,6 +200,8 @@ multiplexer:
 #   reset-conn: true
 #   # Channel buffer size for incoming packets, number of packet before to drop it.
 #   chan-buffer-size: 65535
+#   # Reconstruct DNS payload
+#   add-dns-payload: false
 
 # # tzsp (TaZmen Sniffer Protocol)
 # tzsp:

--- a/dnsutils/constants.go
+++ b/dnsutils/constants.go
@@ -5,10 +5,12 @@ import "crypto/tls"
 const (
 	STR_UNKNOWN = "UNKNOWN"
 
-	PROG_NAME           = "dnscollector"
-	LOCALHOST_IP        = "127.0.0.1"
-	ANY_IP              = "0.0.0.0"
-	HTTP_OK             = "HTTP/1.1 200 OK\r\n\r\n"
+	PROG_NAME    = "dnscollector"
+	LOCALHOST_IP = "127.0.0.1"
+	ANY_IP       = "0.0.0.0"
+	HTTP_OK      = "HTTP/1.1 200 OK\r\n\r\n"
+
+	VALID_DOMAIN        = "dnscollector.dev."
 	BAD_LABEL_DOMAIN    = "ultramegaverytoolonglabel-ultramegaverytoolonglabel-ultramegaverytoolonglabel.dnscollector.dev."
 	BAD_VERYLONG_DOMAIN = "ultramegaverytoolonglabel.dnscollector" +
 		"ultramegaverytoolonglabel-ultramegaverytoolonglabel-" +

--- a/processors/powerdns_test.go
+++ b/processors/powerdns_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dmachard/go-dnscollector/dnsutils"
 	"github.com/dmachard/go-logger"
 	powerdns_protobuf "github.com/dmachard/go-powerdns-protobuf"
+	"github.com/miekg/dns"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -14,8 +15,8 @@ func TestPowerDNS_Processor(t *testing.T) {
 	consumer := NewPdnsProcessor(0, dnsutils.GetFakeConfig(), logger.New(false), "test", 512)
 	chan_to := make(chan dnsutils.DnsMessage, 512)
 
-	// prepare dnstap
-	dnsQname := "test."
+	// init the powerdns processor
+	dnsQname := dnsutils.VALID_DOMAIN
 	dnsQuestion := powerdns_protobuf.PBDNSMessage_DNSQuestion{QName: &dnsQname}
 
 	dm := &powerdns_protobuf.PBDNSMessage{}
@@ -38,7 +39,54 @@ func TestPowerDNS_Processor(t *testing.T) {
 	}
 }
 
-func TestPowerDNS_Processor_InvalidLabelLength(t *testing.T) {
+func TestPowerDNS_Processor_AddDNSPayload_Valid(t *testing.T) {
+	cfg := dnsutils.GetFakeConfig()
+	cfg.Collectors.PowerDNS.AddDnsPayload = true
+
+	// init the powerdns processor
+	consumer := NewPdnsProcessor(0, cfg, logger.New(false), "test", 512)
+	chan_to := make(chan dnsutils.DnsMessage, 1)
+
+	// prepare powerdns message
+	dnsQname := dnsutils.VALID_DOMAIN
+	dnsQuestion := powerdns_protobuf.PBDNSMessage_DNSQuestion{QName: &dnsQname}
+
+	dm := &powerdns_protobuf.PBDNSMessage{}
+	dm.ServerIdentity = []byte("powerdnspb")
+	dm.Type = powerdns_protobuf.PBDNSMessage_DNSQueryType.Enum()
+	dm.SocketProtocol = powerdns_protobuf.PBDNSMessage_DNSCryptUDP.Enum()
+	dm.SocketFamily = powerdns_protobuf.PBDNSMessage_INET.Enum()
+	dm.Question = &dnsQuestion
+
+	data, _ := proto.Marshal(dm)
+
+	// start the consumer and add packet
+	go consumer.Run([]chan dnsutils.DnsMessage{chan_to}, []string{"test"})
+	consumer.GetChannel() <- data
+
+	// read dns message
+	msg := <-chan_to
+
+	// checks
+	if msg.DNS.Length == 0 {
+		t.Errorf("invalid length got %d", msg.DNS.Length)
+	}
+	if len(msg.DNS.Payload) == 0 {
+		t.Errorf("invalid payload length %d", len(msg.DNS.Payload))
+	}
+
+	// valid dns payload ?
+	var decodedPayload dns.Msg
+	err := decodedPayload.Unpack(msg.DNS.Payload)
+	if err != nil {
+		t.Errorf("unpack error %s", err)
+	}
+	if decodedPayload.Question[0].Name != dnsutils.VALID_DOMAIN {
+		t.Errorf("invalid qname in payload: %s", decodedPayload.Question[0].Name)
+	}
+}
+
+func TestPowerDNS_Processor_AddDNSPayload_InvalidLabelLength(t *testing.T) {
 	cfg := dnsutils.GetFakeConfig()
 	cfg.Collectors.PowerDNS.AddDnsPayload = true
 
@@ -48,10 +96,11 @@ func TestPowerDNS_Processor_InvalidLabelLength(t *testing.T) {
 
 	// prepare dnstap
 	dnsQname := dnsutils.BAD_LABEL_DOMAIN
-	dnsQuestion := powerdns_protobuf.PBDNSMessage_DNSQuestion{QName: &dnsQname}
+	dnsQuestion := powerdns_protobuf.PBDNSMessage_DNSQuestion{QName: &dnsQname, QType: proto.Uint32(1), QClass: proto.Uint32(1)}
 
 	dm := &powerdns_protobuf.PBDNSMessage{}
 	dm.ServerIdentity = []byte("powerdnspb")
+	dm.Id = proto.Uint32(2000)
 	dm.Type = powerdns_protobuf.PBDNSMessage_DNSQueryType.Enum()
 	dm.SocketProtocol = powerdns_protobuf.PBDNSMessage_DNSCryptUDP.Enum()
 	dm.SocketFamily = powerdns_protobuf.PBDNSMessage_INET.Enum()
@@ -70,7 +119,7 @@ func TestPowerDNS_Processor_InvalidLabelLength(t *testing.T) {
 	}
 }
 
-func TestPowerDNS_Processor_Qname_TooLongDomain(t *testing.T) {
+func TestPowerDNS_Processor_AddDNSPayload_QnameTooLongDomain(t *testing.T) {
 	cfg := dnsutils.GetFakeConfig()
 	cfg.Collectors.PowerDNS.AddDnsPayload = true
 
@@ -102,7 +151,7 @@ func TestPowerDNS_Processor_Qname_TooLongDomain(t *testing.T) {
 	}
 }
 
-func TestPowerDNS_Processor_Answers_TooLongDomain(t *testing.T) {
+func TestPowerDNS_Processor_AddDNSPayload_AnswersTooLongDomain(t *testing.T) {
 	cfg := dnsutils.GetFakeConfig()
 	cfg.Collectors.PowerDNS.AddDnsPayload = true
 
@@ -111,12 +160,18 @@ func TestPowerDNS_Processor_Answers_TooLongDomain(t *testing.T) {
 	chan_to := make(chan dnsutils.DnsMessage, 512)
 
 	// prepare dnstap
-	dnsQname := "dnscollector.dev."
+	dnsQname := dnsutils.VALID_DOMAIN
 	dnsQuestion := powerdns_protobuf.PBDNSMessage_DNSQuestion{QName: &dnsQname}
 
-	dnsRR := dnsutils.BAD_VERYLONG_DOMAIN
+	rrQname := dnsutils.BAD_VERYLONG_DOMAIN
+	rrDns := powerdns_protobuf.PBDNSMessage_DNSResponse_DNSRR{
+		Name:  &rrQname,
+		Class: proto.Uint32(1),
+		Type:  proto.Uint32(1),
+		Rdata: []byte{0x01, 0x00, 0x00, 0x01},
+	}
 	dnsReply := powerdns_protobuf.PBDNSMessage_DNSResponse{}
-	dnsReply.Rrs = append(dnsReply.Rrs, &powerdns_protobuf.PBDNSMessage_DNSResponse_DNSRR{Name: &dnsRR})
+	dnsReply.Rrs = append(dnsReply.Rrs, &rrDns)
 
 	dm := &powerdns_protobuf.PBDNSMessage{}
 	dm.ServerIdentity = []byte("powerdnspb")
@@ -134,6 +189,8 @@ func TestPowerDNS_Processor_Answers_TooLongDomain(t *testing.T) {
 
 	// read dns message from dnstap consumer
 	msg := <-chan_to
+
+	// tests verifications
 	if !msg.DNS.MalformedPacket {
 		t.Errorf("DNS message is not malformed")
 	}


### PR DESCRIPTION
 go/dnsmessage has been replaced by miekg/dns to avoid empty DNS payload with long domain name