### PR TITLE
add sampling rate to downsampled items

### DIFF
--- a/dnsutils/message.go
+++ b/dnsutils/message.go
@@ -32,6 +32,7 @@ var (
 	ExtractedDirectives       = regexp.MustCompile(`^extracted-*`)
 	ReducerDirectives         = regexp.MustCompile(`^reducer-*`)
 	MachineLearningDirectives = regexp.MustCompile(`^ml-*`)
+	FilteringDirectives       = regexp.MustCompile(`^filtering-*`)
 )
 
 func GetIPPort(dm *DNSMessage) (string, int, string, int) {
@@ -177,6 +178,10 @@ type TransformReducer struct {
 	CumulativeLength int `json:"cumulative-length" msgpack:"cumulative-length"`
 }
 
+type TransformFiltering struct {
+	SampleRate int `json:"sample-rate" msgpack:"sample-rate"`
+}
+
 type TransformML struct {
 	Entropy               float64 `json:"entropy" msgpack:"entropy"`   // Entropy of query name
 	Length                int     `json:"length" msgpack:"length"`     // Length of domain
@@ -211,6 +216,7 @@ type DNSMessage struct {
 	Extracted       *TransformExtracted    `json:"extracted,omitempty" msgpack:"extracted"`
 	Reducer         *TransformReducer      `json:"reducer,omitempty" msgpack:"reducer"`
 	MachineLearning *TransformML           `json:"ml,omitempty" msgpack:"ml"`
+	Filtering       *TransformFiltering    `json:"filtering,omitempty" msgpack:"filtering"`
 }
 
 func (dm *DNSMessage) Init() {
@@ -372,6 +378,17 @@ func (dm *DNSMessage) handleExtractedDirectives(directives []string, s *strings.
 			s.Write(dst)
 		} else {
 			s.WriteString("-")
+		}
+	}
+}
+
+func (dm *DNSMessage) handleFilteringDirectives(directives []string, s *strings.Builder) {
+	if dm.Reducer == nil {
+		s.WriteString("-")
+	} else {
+		switch directive := directives[0]; {
+		case directive == "filtering-samplerate":
+			s.WriteString(strconv.Itoa(dm.Filtering.SampleRate))
 		}
 	}
 }
@@ -572,6 +589,7 @@ func (dm *DNSMessage) Bytes(format []string, fieldDelimiter string, fieldBoundar
 		// more directives from collectors
 		case PdnsDirectives.MatchString(directive):
 			dm.handlePdnsDirectives(directives, &s)
+
 		// more directives from transformers
 		case ReducerDirectives.MatchString(directive):
 			dm.handleReducerDirectives(directives, &s)
@@ -585,6 +603,9 @@ func (dm *DNSMessage) Bytes(format []string, fieldDelimiter string, fieldBoundar
 			dm.handleExtractedDirectives(directives, &s)
 		case MachineLearningDirectives.MatchString(directive):
 			dm.handleMachineLearningDirectives(directives, &s)
+		case FilteringDirectives.MatchString(directive):
+			dm.handleFilteringDirectives(directives, &s)
+
 		// error unsupport directive for text format
 		default:
 			log.Fatalf("unsupport directive for text format: %s", word)

--- a/docs/transformers/transform_trafficfiltering.md
+++ b/docs/transformers/transform_trafficfiltering.md
@@ -21,7 +21,7 @@ Options:
 - `drop-rcodes`: (list of string) rcode list, empty by default
 - `log-queries`: (boolean) drop all queries on false
 - `log-replies`: (boolean)  drop all replies on false
-- `downsample`: (integer) only keep 1 out of every `downsample` records, e.g. if set to 20, then this will return every 20th record, dropping 95% of queries
+- `downsample`: (integer) set the sampling rate, only keep 1 out of every `downsample` records, e.g. if set to 20, then this will return every 20th record (sampling at 1:20 or dropping 95% of queries).
 
 Default values:
 
@@ -46,4 +46,18 @@ Domain list with regex example:
 ```bash
 (mail|wwww).google.com
 github.com
+```
+
+Specific text directive(s) available for the text format:
+
+- `filtering-samplerate`: display the rate applied
+
+When the feature is activated, the following JSON fields are populated in your DNS message:
+
+```json
+{
+  "filtering": {
+    "sample-rate": 20,
+  }
+}
 ```

--- a/transformers/subprocessors.go
+++ b/transformers/subprocessors.go
@@ -172,25 +172,34 @@ func (p *Transforms) Prepare() error {
 }
 
 func (p *Transforms) InitDNSMessageFormat(dm *dnsutils.DNSMessage) {
+	if p.config.Filtering.Enable {
+		p.FilteringTransform.InitDNSMessage(dm)
+	}
+
 	if p.config.GeoIP.Enable {
 		p.GeoipTransform.InitDNSMessage(dm)
 	}
+
 	if p.config.Suspicious.Enable {
 		p.SuspiciousTransform.InitDNSMessage(dm)
 	}
+
 	if p.config.Normalize.Enable {
 		if p.config.Normalize.AddTld || p.config.Normalize.AddTldPlusOne {
 			p.NormalizeTransform.InitDNSMessage(dm)
 		}
 	}
+
 	if p.config.Extract.Enable {
 		if p.config.Extract.AddPayload {
 			p.ExtractProcessor.InitDNSMessage(dm)
 		}
 	}
+
 	if p.config.Reducer.Enable {
 		p.ReducerTransform.InitDNSMessage(dm)
 	}
+
 	if p.config.MachineLearning.Enable {
 		p.MachineLearningTransform.InitDNSMessage(dm)
 	}


### PR DESCRIPTION
This PR introduces a sampling rate in DNSMessage model for downsampled items, addressing the requirement outlined in feature request #407.

The corresponding downsample rate is now incorporated into the JSON DNS message model under the "filtering" section:

```json
"filtering": {
		"sample-rate": "20"
}
```

Additionally, a new directive, filtering-samplerate, has been introduced for the text format.
