### PR TITLE
New length-unit attribute for text-format #478

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -40,7 +40,8 @@ global:
   # - id: dns id
   # - family: ip protocol version INET or INET6
   # - protocol: protocol UDP, TCP
-  # - length: the length of the query or reply
+  # - length: the length of the query or reply in bytes
+  # - length-unit: the length of the query or reply in bytes with unit
   # - qtype: dns qtype
   # - qname: dns qname
   # - latency: computed latency between queries and replies
@@ -56,7 +57,7 @@ global:
   # - edns-csubnet: client subnet
   # - df: ip defragmentation flag
   # - tr: tcp reassembled flag
-  text-format: "timestamp-rfc3339ns identity operation rcode queryip queryport family protocol length qname qtype latency"
+  text-format: "timestamp-rfc3339ns identity operation rcode queryip queryport family protocol length-unit qname qtype latency"
   # default text field delimiter
   text-format-delimiter: " "
   # default text field boundary

--- a/dnsutils/config.go
+++ b/dnsutils/config.go
@@ -520,7 +520,7 @@ type Config struct {
 
 func (c *Config) SetDefault() {
 	// global config
-	c.Global.TextFormat = "timestamp identity operation rcode queryip queryport family protocol length qname qtype latency"
+	c.Global.TextFormat = "timestamp identity operation rcode queryip queryport family protocol length-unit qname qtype latency"
 	c.Global.TextFormatDelimiter = " "
 	c.Global.TextFormatBoundary = "\""
 

--- a/dnsutils/message.go
+++ b/dnsutils/message.go
@@ -522,8 +522,10 @@ func (dm *DNSMessage) Bytes(format []string, fieldDelimiter string, fieldBoundar
 			s.WriteString(dm.NetworkInfo.Family)
 		case directive == "protocol":
 			s.WriteString(dm.NetworkInfo.Protocol)
-		case directive == "length":
+		case directive == "length-unit":
 			s.WriteString(strconv.Itoa(dm.DNS.Length) + "b")
+		case directive == "length":
+			s.WriteString(strconv.Itoa(dm.DNS.Length))
 		case directive == "qname":
 			if len(dm.DNS.Qname) == 0 {
 				s.WriteString(".")

--- a/dnsutils/message_test.go
+++ b/dnsutils/message_test.go
@@ -335,6 +335,11 @@ func TestDnsMessage_TextFormat_DefaultDirectives(t *testing.T) {
 		{
 			format:   "length",
 			dm:       DNSMessage{DNS: DNS{Length: 42}},
+			expected: "42",
+		},
+		{
+			format:   "length-unit",
+			dm:       DNSMessage{DNS: DNS{Length: 42}},
 			expected: "42b",
 		},
 		{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,7 +82,8 @@ Default directives:
 - `id`: dns id
 - `family`: ip protocol version INET or INET6
 - `protocol`: protocol UDP, TCP
-- `length`: the length of the query or reply
+- `length`: the length of the query or reply in bytes
+- `length-unit`: the length of the query or reply in bytes with unit (`b`)
 - `qtype`: dns qtype
 - `qname`: dns qname
 - `latency`: computed latency between queries and replies
@@ -101,7 +102,7 @@ Default directives:
 
 ```yaml
 global:
-  text-format: "timestamp-rfc3339ns identity qr operation rcode queryip queryport family protocol length qname qtype latency ttl"
+  text-format: "timestamp-rfc3339ns identity qr operation rcode queryip queryport family protocol length-unit qname qtype latency ttl"
   text-format-delimiter: " "
   text-format-boundary: "\""
 ```


### PR DESCRIPTION
The current `length` attribute has been renamed to `length-unit`: 
The  `length` attribute is always available but without the `b` at the end.
