### PR TITLE
Rename dnstap logger (breaking changes)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -306,7 +306,7 @@ multiplexer:
 #   chan-buffer-size: 65535
 
 # # resend captured dns traffic to another dnstap collector or to unix socket
-# dnstap:
+# dnstapclient:
 #   # network transport to use: unix|tcp|tcp+tls
 #   transport: tcp
 #   # remote address

--- a/docs/_examples/use-case-12.yml
+++ b/docs/_examples/use-case-12.yml
@@ -20,11 +20,11 @@ multiplexer:
   # Redirect DNSTap to two destinations
   loggers:
     - name: relay-out1
-      dnstap:
+      dnstapclient:
         remote-address: 127.0.0.1
         remote-port: 6001
     - name: relay-out2
-      dnstap:
+      dnstapclient:
         remote-address: 127.0.0.1
         remote-port: 6002
 

--- a/docs/_examples/use-case-16.yml
+++ b/docs/_examples/use-case-16.yml
@@ -16,7 +16,7 @@ multiplexer:
   # Redirect output to a remote DNStap collector
   loggers:
     - name: tap
-      dnstap:
+      dnstapclient:
         remote-address: 127.0.0.1
         remote-port: 6002
 

--- a/docs/_examples/use-case-5.yml
+++ b/docs/_examples/use-case-5.yml
@@ -20,7 +20,7 @@ multiplexer:
   # Sends to another DNSTap collector with TLS
   loggers:
     - name: tap_tls
-      dnstap:
+      dnstapclient:
         remote-address: 127.0.0.1
         remote-port:  6000
         tls-support: true

--- a/docs/loggers/logger_dnstap.md
+++ b/docs/loggers/logger_dnstap.md
@@ -25,7 +25,7 @@ Options:
 Default values:
 
 ```yaml
-dnstap:
+dnstapclient:
   transport: tcp
   remote-address: 10.0.0.1
   remote-port: 6000

--- a/pkgconfig/loggers.go
+++ b/pkgconfig/loggers.go
@@ -77,7 +77,7 @@ type ConfigLoggers struct {
 		OverwriteIdentity bool   `yaml:"overwrite-identity"`
 		BufferSize        int    `yaml:"buffer-size"`
 		ChannelBufferSize int    `yaml:"chan-buffer-size"`
-	} `yaml:"dnstap"`
+	} `yaml:"dnstapclient"`
 	TCPClient struct {
 		Enable            bool   `yaml:"enable"`
 		RemoteAddress     string `yaml:"remote-address"`


### PR DESCRIPTION
The `dnstap` logger is renamed to `dnstapclient`.
The YAML name of each loggers or collectors must be uniq to support the future `pipeline` mode.