### PR TITLE
fix bad yaml key for dnstap-relay collector 

### DIFF
--- a/pkgconfig/collectors.go
+++ b/pkgconfig/collectors.go
@@ -41,7 +41,7 @@ type ConfigCollectors struct {
 		TLSMinVersion string `yaml:"tls-min-version"`
 		CertFile      string `yaml:"cert-file"`
 		KeyFile       string `yaml:"key-file"`
-	} `yaml:"dnstap-proxifier"`
+	} `yaml:"dnstap-relay"`
 	AfpacketLiveCapture struct {
 		Enable            bool   `yaml:"enable"`
 		Port              int    `yaml:"port"`


### PR DESCRIPTION
This patch fixes the issue reported on https://github.com/dmachard/go-dnscollector/issues/516#issuecomment-1892754164
