### PR TITLE
Support of DNSTap extra field on outgoing messages

### DIFF
--- a/dnsutils/message.go
+++ b/dnsutils/message.go
@@ -736,6 +736,11 @@ func (dm *DNSMessage) ToDNSTap() ([]byte, error) {
 
 	dt.Message = msg
 
+	// add dnstap extra
+	if len(dm.DNSTap.Extra) > 0 {
+		dt.Extra = []byte(dm.DNSTap.Extra)
+	}
+
 	data, err := proto.Marshal(dt)
 	if err != nil {
 		return nil, err

--- a/dnsutils/message_test.go
+++ b/dnsutils/message_test.go
@@ -7,7 +7,35 @@ import (
 	"testing"
 
 	"github.com/dmachard/go-dnscollector/pkgconfig"
+	"github.com/dmachard/go-dnstap-protobuf"
+	"google.golang.org/protobuf/proto"
 )
+
+func TestDnsMessage_Encode_ToDNSTap(t *testing.T) {
+	dm := GetFakeDNSMessageWithPayload()
+	dm.DNSTap.Extra = "extra:value"
+
+	// encode to dnstap
+	tapMsg, err := dm.ToDNSTap()
+	if err != nil {
+		t.Fatalf("could not encode to dnstap: %v\n", err)
+	}
+
+	// decode dnstap message
+	dt := &dnstap.Dnstap{}
+	err = proto.Unmarshal(tapMsg, dt)
+	if err != nil {
+		t.Fatalf("error to decode dnstap: %v", err)
+	}
+
+	if string(dt.GetIdentity()) != dm.DNSTap.Identity {
+		t.Errorf("identify field should be equal got=%s", string(dt.GetIdentity()))
+	}
+
+	if string(dt.GetExtra()) != dm.DNSTap.Extra {
+		t.Errorf("extra field should be equal got=%s", string(dt.GetExtra()))
+	}
+}
 
 func TestDnsMessage_Json_Reference(t *testing.T) {
 	dm := DNSMessage{}

--- a/processors/dnstap.go
+++ b/processors/dnstap.go
@@ -120,46 +120,8 @@ func (d *DNSTapProcessor) Stop() {
 	d.LogInfo("stopping to process...")
 	d.stopRun <- true
 	<-d.doneRun
-
-	// d.LogInfo("stopping to monitor loggers...")
-	// d.stopMonitor <- true
-	// <-d.doneMonitor
 }
 
-// func (d *DNSTapProcessor) MonitorLoggers() {
-// 	// watchInterval := 10 * time.Second
-// 	// bufferFull := time.NewTimer(watchInterval)
-// MONITOR_LOOP:
-// 	for {
-// 		select {
-// 		case <-d.stopMonitor:
-// 			// close(d.dropped)
-// 			// bufferFull.Stop()
-// 			d.doneMonitor <- true
-// 			break MONITOR_LOOP
-
-// case loggerName := <-d.dropped:
-// 	if _, ok := d.droppedCount[loggerName]; !ok {
-// 		d.droppedCount[loggerName] = 1
-// 	} else {
-// 		d.droppedCount[loggerName]++
-// 	}
-
-// case <-bufferFull.C:
-// 	for v, k := range d.droppedCount {
-// 		if k > 0 {
-// 			d.LogError("logger[%s] buffer is full, %d packet(s) dropped", v, k)
-// 			d.droppedCount[v] = 0
-// 		}
-// 	}
-// 	bufferFull.Reset(watchInterval)
-
-// 		}
-// 	}
-// 	d.LogInfo("monitor terminated")
-// }
-
-// func (d *DNSTapProcessor) Run(loggersChannel []chan dnsutils.DNSMessage, loggersName []string) {
 func (d *DNSTapProcessor) Run(defaultWorkers []pkgutils.Worker, droppedworkers []pkgutils.Worker) {
 	dt := &dnstap.Dnstap{}
 

--- a/processors/dnstap.go
+++ b/processors/dnstap.go
@@ -132,9 +132,6 @@ func (d *DNSTapProcessor) Run(defaultWorkers []pkgutils.Worker, droppedworkers [
 	// prepare enabled transformers
 	transforms := transformers.NewTransforms(&d.config.IngoingTransformers, d.logger, d.name, defaultRoutes, d.ConnID)
 
-	// start goroutine to count dropped messsages
-	// go d.MonitorLoggers()
-
 	// read incoming dns message
 	d.LogInfo("waiting dns message to process...")
 RUN_LOOP:


### PR DESCRIPTION
This PR add the support of DNSTap extra field for the DNSTap logger as reported in  https://github.com/dmachard/go-dnscollector/issues/516

Only string values are supported.

