### PR TITLE
feat: extend text-format by rdatatype and rdatatypes

### DIFF
--- a/dnsutils/dnsmessage_text.go
+++ b/dnsutils/dnsmessage_text.go
@@ -610,6 +610,33 @@ func (dm *DNSMessage) ToTextLine(format []string, fieldDelimiter string, fieldBo
 				s.WriteByte('-')
 			}
 
+		case directive == "rdatatype":
+			ansFound := false
+			for _, answer := range an {
+				s.WriteString(answer.Rdatatype)
+				ansFound = true
+				break
+			}
+
+			if !ansFound {
+				s.WriteByte('-')
+			}
+
+		case directive == "rdatatypes":
+			ansFound := false
+			var rDataTypes []string
+
+			for _, answer := range an {
+				rDataTypes = append(rDataTypes, answer.Rdatatype)
+				ansFound = true
+			}
+			if !ansFound {
+				s.WriteByte('-')
+			} else {
+				s.WriteString(strings.Join(rDataTypes, ";"))
+
+			}
+
 		case directive == "questionscount" || directive == "qdcount":
 			s.WriteString(strconv.Itoa(dm.DNS.QdCount))
 		case directive == "answercount" || directive == "ancount":

--- a/dnsutils/dnsmessage_text_test.go
+++ b/dnsutils/dnsmessage_text_test.go
@@ -305,6 +305,54 @@ func TestDnsMessage_TextFormat_DefaultDirectives(t *testing.T) {
 			expected: "127.0.0.1;127.0.0.2",
 		},
 		{
+			format: "rdatatype",
+			dm: DNSMessage{
+				DNS: DNS{
+					DNSRRs: DNSRRs{
+						Answers: []DNSAnswer{
+							{
+								Name:      "dnscollector.fr",
+								Rdatatype: "A",
+								Class:     "IN",
+								Rdata:     "127.0.0.1",
+							},
+							{
+								Name:      "dnscollector.fr",
+								Rdatatype: "A",
+								Class:     "IN",
+								Rdata:     "127.0.0.2",
+							},
+						},
+					},
+				},
+			},
+			expected: "A",
+		},
+		{
+			format: "rdatatypes",
+			dm: DNSMessage{
+				DNS: DNS{
+					DNSRRs: DNSRRs{
+						Answers: []DNSAnswer{
+							{
+								Name:      "dnscollector.fr",
+								Rdatatype: "A",
+								Class:     "IN",
+								Rdata:     "127.0.0.1",
+							},
+							{
+								Name:      "dnscollector.fr",
+								Rdatatype: "A",
+								Class:     "IN",
+								Rdata:     "127.0.0.2",
+							},
+						},
+					},
+				},
+			},
+			expected: "A;A",
+		},
+		{
 			format:   "http-protocol",
 			dm:       DNSMessage{DNSTap: DNSTap{HttpProtocol: "HTTP3"}},
 			expected: "HTTP3",

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -27,6 +27,8 @@ Highly customizable text output using field directives:
 **DNS Information**
 - `operation` - DNStap operation (CLIENT_QUERY, etc.)
 - `rcode` - DNS response code
+- `rdatatype` - DNS response type (A, AAAA, etc.)
+- `rdatatypes` - DNS response types (semicolon separated)
 - `qname` - Query domain name
 - `qtype` - Query type (A, AAAA, etc.)
 - `qclass` - Query class


### PR DESCRIPTION
This PR extends the text-format functionality by adding support for rdatatype which return type of the first answer and rdatatypes which returns types of all answers.