### PR TITLE
Fix: Correct Swapped Cache TTL and Size Default Values

### DIFF
--- a/pkgconfig/loggers.go
+++ b/pkgconfig/loggers.go
@@ -43,18 +43,18 @@ type ConfigLoggers struct {
 		NonExistentMetricsEnabled bool     `yaml:"nonexistent-metrics-enabled" default:"true"`
 		TimeoutMetricsEnabled     bool     `yaml:"timeout-metrics-enabled" default:"false"`
 		HistogramMetricsEnabled   bool     `yaml:"histogram-metrics-enabled" default:"false"`
-		RequestersCacheTTL        int 	   `yaml:"requesters-cache-ttl" default:"3600"`
-		RequestersCacheSize       int 	   `yaml:"requesters-cache-size" default:"250000"`
-		DomainsCacheTTL           int 	   `yaml:"domains-cache-ttl" default:"3600"`
-		DomainsCacheSize          int 	   `yaml:"domains-cache-size" default:"500000"`
-		NoErrorDomainsCacheTTL    int 	   `yaml:"noerror-domains-cache-ttl" default:"3600"`
-		NoErrorDomainsCacheSize   int 	   `yaml:"noerror-domains-cache-size" default:"100000"`
-		ServfailDomainsCacheTTL   int 	   `yaml:"servfail-domains-cache-ttl" default:"3600"`
-		ServfailDomainsCacheSize  int 	   `yaml:"servfail-domains-cache-size" default:"10000"`
-		NXDomainsCacheTTL         int 	   `yaml:"nonexistent-domains-cache-ttl" default:"3600"`
-		NXDomainsCacheSize        int 	   `yaml:"nonexistent-domains-cache-size" default:"10000"`
-		DefaultDomainsCacheTTL    int 	   `yaml:"default-domains-cache-ttl" default:"3600"`
-		DefaultDomainsCacheSize   int 	   `yaml:"default-domains-cache-size" default:"1000"`
+		RequestersCacheTTL        int      `yaml:"requesters-cache-ttl" default:"3600"`
+		RequestersCacheSize       int      `yaml:"requesters-cache-size" default:"250000"`
+		DomainsCacheTTL           int      `yaml:"domains-cache-ttl" default:"3600"`
+		DomainsCacheSize          int      `yaml:"domains-cache-size" default:"500000"`
+		NoErrorDomainsCacheTTL    int      `yaml:"noerror-domains-cache-ttl" default:"3600"`
+		NoErrorDomainsCacheSize   int      `yaml:"noerror-domains-cache-size" default:"100000"`
+		ServfailDomainsCacheTTL   int      `yaml:"servfail-domains-cache-ttl" default:"3600"`
+		ServfailDomainsCacheSize  int      `yaml:"servfail-domains-cache-size" default:"10000"`
+		NXDomainsCacheTTL         int      `yaml:"nonexistent-domains-cache-ttl" default:"3600"`
+		NXDomainsCacheSize        int      `yaml:"nonexistent-domains-cache-size" default:"10000"`
+		DefaultDomainsCacheTTL    int      `yaml:"default-domains-cache-ttl" default:"3600"`
+		DefaultDomainsCacheSize   int      `yaml:"default-domains-cache-size" default:"1000"`
 	} `yaml:"prometheus"`
 	RestAPI struct {
 		Enable            bool   `yaml:"enable" default:"false"`


### PR DESCRIPTION
The cache configuration struct had mismatched default values where TTL fields were holding size defaults and size fields were holding TTL defaults. This caused incorrect behavior when loading configuration via YAML defaults.

### What’s Changed

- Updated default values across all cache fields:
```
RequestersCacheTTL / RequestersCacheSize
DomainsCacheTTL / DomainsCacheSize
NoErrorDomainsCacheTTL / NoErrorDomainsCacheSize
ServfailDomainsCacheTTL / ServfailDomainsCacheSize
NXDomainsCacheTTL / NXDomainsCacheSize
DefaultDomainsCacheTTL / DefaultDomainsCacheSize
```
- Ensures TTL fields now represent TTL defaults and Size fields represent size defaults.

### Testing

I did not test it. 