### PR TITLE
feat: add support for SCRAM-SHA-256 SASL mechanism in Kafka producer

### DIFF
--- a/docs/loggers/logger_kafka.md
+++ b/docs/loggers/logger_kafka.md
@@ -54,7 +54,7 @@ Options:
 
 * `sasl-mechanism` (string)
   > Specifies the SASL mechanism to use for authentication with Kafka brokers.
-  > SASL mechanism: `PLAIN` or `SCRAM-SHA-512`.
+  > SASL mechanism: `PLAIN`, `SCRAM-SHA-512` or `SCRAM-SHA-256` .
 
 * `mode` (string)
   > Specifies the output format for Kafka messages. Output format: `text`, `json`, or `flat-json`.

--- a/pkgconfig/constants.go
+++ b/pkgconfig/constants.go
@@ -25,8 +25,9 @@ const (
 	ModePCAP     = "pcap"
 	ModeDNSTap   = "dnstap"
 
-	SASLMechanismPlain = "PLAIN"
-	SASLMechanismScram = "SCRAM-SHA-512"
+	SASLMechanismPlain  = "PLAIN"
+	SASLMechanismSha512 = "SCRAM-SHA-512"
+	SASLMechanismSha256 = "SCRAM-SHA-256"
 
 	CompressGzip   = "gzip"
 	CompressSnappy = "snappy"


### PR DESCRIPTION
Update constants to include SCRAM-SHA-256
Modify Kafka producer code to handle SCRAM-SHA-256 authentication 
Update documentation to reflect new SASL mechanism options