### PR TITLE
feat: add Client ID configuration for Kafka producer

### DIFF
--- a/docs/loggers/logger_kafka.md
+++ b/docs/loggers/logger_kafka.md
@@ -18,6 +18,9 @@ Options:
   > Remote tcp port.
   > Specifies the remote TCP port to connect to.
 
+* `client-id` (string)
+  >Unique identifier for Kafka Client,Using Client IDs to manage client traffic on the Kafka server.
+
 * `connect-timeout` (integer)
   > Specifies the maximum time to wait for a connection attempt to complete.
 

--- a/pkgconfig/loggers.go
+++ b/pkgconfig/loggers.go
@@ -293,6 +293,7 @@ type ConfigLoggers struct {
 	} `yaml:"redispub"`
 	KafkaProducer struct {
 		Enable            bool   `yaml:"enable" default:"false"`
+		ClientID          string `yaml:"client-id" default:""`
 		RemoteAddress     string `yaml:"remote-address" default:"127.0.0.1"`
 		RemotePort        int    `yaml:"remote-port" default:"9092"`
 		TLSSupport        bool   `yaml:"tls-support" default:"false"`

--- a/workers/kafkaproducer.go
+++ b/workers/kafkaproducer.go
@@ -90,6 +90,7 @@ func (w *KafkaProducer) createDialer() *kafka.Dialer {
 	dialer := &kafka.Dialer{
 		Timeout:   time.Duration(kafkaConfig.ConnectTimeout) * time.Second,
 		DualStack: true,
+		ClientID:  kafkaConfig.ClientID,
 	}
 
 	// TLS Support


### PR DESCRIPTION
Add support for configuring Client ID in Kafka producer to enable better client identification and traffic management on Kafka server.