### PR TITLE
Update Go base image version to 1.25.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6-alpine AS builder
+FROM golang:1.25.7-alpine AS builder
 
 ARG VERSION
 


### PR DESCRIPTION
Version 1.25.6 has a critical vulnerability, see also https://pkg.go.dev/vuln/GO-2026-4337