### PR TITLE
Update Go base image version to 1.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0-alpine AS builder
+FROM golang:1.26.1-alpine AS builder
 
 ARG VERSION
 


### PR DESCRIPTION
Version 1.26.1 fixes two vulnerabilities, it would be good to update the image

* https://pkg.go.dev/vuln/GO-2026-4601
* https://pkg.go.dev/vuln/GO-2026-4599

Thanks!